### PR TITLE
Fix/mute functionality

### DIFF
--- a/game/options.rpy
+++ b/game/options.rpy
@@ -60,7 +60,7 @@ define default_voice_volume = 1.0
 # Mute state variable
 define is_muted = False
 
-# options.rpy or audio.rpy
+
 
 init python:
     def mute_all():

--- a/game/options.rpy
+++ b/game/options.rpy
@@ -51,12 +51,35 @@ define config.has_music = True
 define config.has_voice = True
 
 
+
+# Default volume settings
+define default_sound_volume = 1.0  # 100% volume
+define default_music_volume = 1.0
+define default_voice_volume = 1.0
+
+# Mute state variable
+define is_muted = False
+
+# options.rpy or audio.rpy
+
+init python:
+    def mute_all():
+        renpy.music.set_volume(0.0, channel='music')  # Mute music
+        renpy.sound.set_volume(0.0, channel='sound')  # Mute sound effects
+        renpy.sound.set_volume(0.0, channel='voice')  # Mute voice
+        Preference("all mute", True)  # Update preference
+
+    def unmute_all():
+        renpy.music.set_volume(default_music_volume, channel='music')
+        renpy.sound.set_volume(default_sound_volume, channel='sound')
+        renpy.sound.set_volume(default_voice_volume, channel='voice')
+        Preference("all mute", False)  # Update preference
+
 ## To allow the user to play a test sound on the sound or voice channel,
 ## uncomment a line below and use it to set a sample sound to play.
 
 # define config.sample_sound = "sample-sound.ogg"
 # define config.sample_voice = "sample-voice.ogg"
-
 
 ## Uncomment the following line to set an audio file that will be played while
 ## the player is at the main menu. This file will continue playing into the

--- a/game/screens.rpy
+++ b/game/screens.rpy
@@ -804,9 +804,11 @@ screen preferences():
                         null height gui.pref_spacing
 
                         textbutton _("Mute All"):
-                            action Preference("all mute", "toggle")
+                            action [
+                                If(is_muted, Function(unmute_all), Function(mute_all)),  # Toggle between mute and unmute
+                                SetVariable("is_muted", not is_muted)  # Toggle the mute state
+                            ]
                             style "mute_all_button"
-
 
 style pref_label is gui_label
 style pref_label_text is gui_label_text


### PR DESCRIPTION
#3 
This pull request implements the mute functionality for all audio channels in the game. When the "Mute All" button is clicked, all audio (music, sound effects, and voice) is muted simultaneously.

Moreover, It addresses a previous issue where unmuting would restart the music track. Now, when the user clicks  "Mute All" and then un-mutes, the music will resume from its last position rather than starting over.

This enhancement improves the user experience by providing smoother audio control.